### PR TITLE
Use the development repository instead of stable to install openvnet

### DIFF
--- a/openvnet.repo/xexecscript.d/openvnet.repo.sh
+++ b/openvnet.repo/xexecscript.d/openvnet.repo.sh
@@ -9,10 +9,12 @@ set -o pipefail
 declare chroot_dir=$1
 
 chroot $1 $SHELL -ex <<'EOS'
-  until curl -fsSkL -o /etc/yum.repos.d/openvnet.repo https://raw.githubusercontent.com/axsh/openvnet/master/deployment/yum_repositories/stable/openvnet.repo; do
+  until curl -fsSkL -o /etc/yum.repos.d/openvnet.repo https://raw.githubusercontent.com/axsh/openvnet/develop/deployment/yum_repositories/development/openvnet.repo; do
     sleep 1
   done
-  until curl -fsSkL -o /etc/yum.repos.d/openvnet-third-party.repo https://raw.githubusercontent.com/axsh/openvnet/master/deployment/yum_repositories/stable/openvnet-third-party.repo; do
+
+
+  until curl -fsSkL -o /etc/yum.repos.d/openvnet-third-party.repo https://raw.githubusercontent.com/axsh/openvnet/develop/deployment/yum_repositories/development/openvnet-third-party.repo; do
     sleep 1
   done
 EOS


### PR DESCRIPTION
This actually doesn't affect the CI because it always installs feature braches using the scripts on jenkins. When building locally though, it makes more sense to use the latest development packages.